### PR TITLE
Remove contributing guide link and switch "Join MONAI" link to point to contributing guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,10 +327,7 @@
                     <p>Project MONAI is an initiative originally started by NVIDIA & King’s College London to establish an inclusive community of AI researchers for the development and exchange of best practices for AI in healthcare imaging across academia
                       and enterprise researchers.
                     </p>
-                    <a href="https://github.com/Project-MONAI" target="_blank"><button class="rounded-full px-6 py-2 my-4 text-white bg-brand-primary">Join Project MONAI</button></a>
-                    <a href="https://github.com/Project-MONAI/MONAI/blob/master/CONTRIBUTING.md" target="_blank">
-                      <p class="text-lg font-medium bold pb-4 external-link">Contributing Guidelines</p>
-                    </a>
+                    <a href="https://github.com/Project-MONAI/MONAI/blob/dev/CONTRIBUTING.md" target="_blank"><button class="rounded-full px-6 py-2 my-4 text-white bg-brand-primary">Join Project MONAI</button></a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Right now, when you click join, it just takes you to GitHub with no context as to what you should do next. It would be good to get this link updated to a more actionable step.