### PR TITLE
Add cross-references between Advisory Board and Working Groups pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -61,10 +61,16 @@
             They provide strategic oversight across various aspects including technical development, clinical validation, educational 
             initiatives, and community engagement.
           </p>
-          <p class="text-gray-700 mb-6">
+          <p class="text-gray-700 mb-4">
             Through regular collaboration with working groups and the broader community, the Advisory Board ensures that MONAI 
             continues to meet the evolving needs of researchers, clinicians, and industry partners while advancing the field of 
             medical imaging AI.
+          </p>
+          <p class="text-gray-700 mb-6">
+            Our <a href="working-groups.html" class="text-brand-primary hover:text-brand-dark underline">Working Groups</a> are driven at the Advisory Board level, 
+            with each working group lead serving as a member of the Advisory Board. These specialized teams focus on key areas 
+            including core development, deployment, education, benchmarking, federated learning, AI-human interaction, outreach, 
+            and clinical applications such as ophthalmology and ultrasound.
           </p>
         </div>
 

--- a/working-groups.html
+++ b/working-groups.html
@@ -42,6 +42,12 @@
                 Working group members collaborate regularly through meetings, workshops, and joint projects, fostering knowledge exchange 
                 and driving continuous improvement in their specialized areas.
               </p>
+              <p class="text-lg leading-relaxed text-gray-700">
+                Each working group is led by chairs who serve as members of the MONAI <a href="about.html#advisory-board" class="text-brand-primary hover:text-brand-dark underline">Advisory Board</a>, 
+                ensuring strategic alignment with MONAI's overall mission and vision. The Advisory Board provides governance and strategic 
+                direction, guiding these working groups to address the most critical challenges in medical imaging AI while maintaining 
+                technical excellence and clinical relevance.
+              </p>
             </div>
           </div>
           <div class="flex justify-center w-full lg:w-1/2">


### PR DESCRIPTION
## Summary
- Added link from Advisory Board page to Working Groups page
- Added link from Working Groups page to Advisory Board section
- Improved navigation between related governance pages

## Changes
1. **about.html**: Added paragraph explaining that Working Groups are led by Advisory Board members with link to working-groups.html
2. **working-groups.html**: Added paragraph explaining Advisory Board governance role with link to about.html#advisory-board