### PR TITLE
Fix main element padding to match navbar height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .ipynb_checkpoints
 dist/
+.claude/

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <body class="flex flex-col min-h-screen">
   <!-- #include file="components/header.html" -->
 
-  <main class="flex-grow pt-20">
+  <main class="flex-grow pt-16">
     <!-- About Section -->
     <section id="about" class="py-24 bg-white">
       <div class="container">

--- a/core.html
+++ b/core.html
@@ -15,7 +15,7 @@
 <body class="flex flex-col min-h-screen">
     <!-- #include file="components/header.html" -->
 
-    <main class="flex-grow pt-20">
+    <main class="flex-grow pt-16">
         <!-- Overview Section -->
         <section id="overview" class="py-24 bg-white">
             <div class="container">

--- a/deploy.html
+++ b/deploy.html
@@ -172,7 +172,7 @@
 <body class="flex flex-col min-h-screen">
     <!-- #include file="components/header.html" -->
 
-    <main class="flex-grow pt-20">
+    <main class="flex-grow pt-16">
         <!-- Overview Section -->
         <section id="overview" class="py-24 bg-white">
             <div class="container">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <body class="flex flex-col min-h-screen">
     <!-- #include file="components/header.html" -->
 
-    <main class="flex-grow pt-20">
+    <main class="flex-grow pt-16">
         <!-- Hero Area Start -->
         <section id="hero-area" class="relative pb-20 bg-white overflow-hidden">
             <!-- Particles.js container -->

--- a/label.html
+++ b/label.html
@@ -15,7 +15,7 @@
 <body class="flex flex-col min-h-screen">
     <!-- #include file="components/header.html" -->
 
-    <main class="flex-grow pt-20">
+    <main class="flex-grow pt-16">
         <!-- Overview Section -->
         <section id="overview" class="py-24 bg-white">
             <div class="container">

--- a/model-zoo.html
+++ b/model-zoo.html
@@ -16,7 +16,7 @@
 <body class="flex flex-col min-h-screen">
     <!-- #include file="components/header.html" -->
 
-    <main class="flex-grow pt-20">
+    <main class="flex-grow pt-16">
         <div id="app"></div>
     </main>
 

--- a/working-groups.html
+++ b/working-groups.html
@@ -17,7 +17,7 @@
 
   <!-- #include file="components/header.html" -->
 
-  <main class="flex-grow pt-20">
+  <main class="flex-grow pt-16">
     <!-- Hero Section -->
     <section class="py-24 bg-white ">
       <div class="container">


### PR DESCRIPTION
- Change pt-20 to pt-16 on main elements to properly align with 4rem navbar height
- Ensures consistent spacing when banner system dynamically adjusts padding
- Prevents visual jumps when banner is shown/hidden
- Add .claude/ to gitignore